### PR TITLE
Fix null reference for items that lack collection attributes

### DIFF
--- a/ItemRarity/ItemRarity/Patches/CollectibleObjectPatch.cs
+++ b/ItemRarity/ItemRarity/Patches/CollectibleObjectPatch.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.CompilerServices;
 using System.Text;
 using HarmonyLib;
@@ -104,7 +104,10 @@ public static class CollectibleObjectPatch
 
         var rarity = ModRarity.GetRandomRarity();
 
-        itemStack.SetRarity(rarity.Key);
+        if (ModRarity.IsValidForRarity(itemStack, true))
+        {
+            itemStack.SetRarity(rarity.Key);
+        }
     }
 
     [HarmonyReversePatch, HarmonyPatch(nameof(CollectibleObject.GetHeldItemInfo))]

--- a/ItemRarity/ItemRarity/modinfo.json
+++ b/ItemRarity/ItemRarity/modinfo.json
@@ -4,7 +4,7 @@
   "side:": "universal",
   "name": "ItemRarity",
   "description": "This mod introduces a rarity mechanic to items. Rarity levels influence key item stats, such as durability, damage, and more.",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "website": "https://github.com/raevendev/itemrarity",
   "authors": [
     "Unreal852"


### PR DESCRIPTION
Fix null reference for items that lack collection attributes, e,g. whetstones for repairMe